### PR TITLE
possible memory leak in inactive connection linked list

### DIFF
--- a/queue.js
+++ b/queue.js
@@ -83,7 +83,9 @@ var connectionPrototype = {
 							leastRecentlyUsed.close();
 						}
 						leastRecentlyUsed = leastRecentlyUsed.next;
-						leastRecentlyUsed.previous = null;
+						if (leastRecentlyUsed) {
+							leastRecentlyUsed.previous = null;
+						}
 					}
 				}, 1000);
 			}


### PR DESCRIPTION
@kriszyp i could really do with a sanity check here if you've got the time.

yesterday i launched a beta release of a site i've built using persevere.  immediately we started to notice a lot more memory consumption than anticipated.  at the same time, we seemed to have some unrelated issues with real-time updates that i had to look into.  in looking into the real-time issues i became suspicious that the linked list of inactive connections may also be responsible for some of the memory usage.  once the dust settles i plan to take some heap snapshots from node to do some real analysis of the memory usage but for now i'm putting out fires.

i started to look into the queue because at times i was getting the "oh no" error indicating that the linked list had been reduced to a single element with circular references to itself.

i found that when connections were being made active or being closed their references to `next` and `previous` weren't being cleared.  this meant that if you had an inactive list of A-B-C then if B became active it would still point to A and C via `previous` and `next` respectively.  if B then became inactive you would end up with A-C-B-C (B added to the front but still with a reference to C via `next`).  then
if B became active again and A was closed, you're left with C-C and you get the "oh no" error.

when a connection was being reaped, `leastRecentlyUsed` was being moved forward in the list but the new `leastRecentlyUsed.previous` still pointed to the connection that was reaped.  this is the part where i think i may be experiencing some leaks.

i'd really appreciate if you could look at this and let me know if my reasoning is wrong.

thanks.
